### PR TITLE
Git and Node are requirements for installation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
 ![Hermie The Crab](/icon.png)
 
-# Scuttle Shell 
+# Scuttle Shell
 
 This is a [Secure Scuttlebutt](http://scuttlebutt.nz) system tray application. It provides an always-running _sbot_ for your local system.
 
 This app also setups itself as a [Native Host App](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Native_messaging) that can be used by **authorized Firefox Add-ons** such as [Patchfox](https://github.com/soapdog/patchfox).
+
+## Dependencies
+
+You must have [Git](https://git-scm.com) and [Node](https://nodejs.org) installed.
 
 ## Install globally
 
@@ -15,7 +19,7 @@ $ npm install -g scuttle-shell
 or if you cloned this repo (run from the repo folder itself):
 
 ```
-$ npm install -g 
+$ npm install -g
 ```
 
 You can run the app by executing `scuttleshell` on your terminal.
@@ -43,8 +47,8 @@ $ npm install
 
 This should set it up. If anything fails you can check your setup with
 
-
 ### Checking your setup
+
 Depending on your running operating system, you can check the configuration using:
 
 ```
@@ -58,6 +62,7 @@ $ npm run check-win
 ```
 
 ### Running Setup (again)
+
 If anything went wrong during the setup or if you rename the folder this app is in, you can redo the setup with:
 
 ```


### PR DESCRIPTION
When attempting to investigate #10 I found that my fresh virtual box ubuntu with node installed actually wouldn't install scuttle-shell because Git was missing. This was surprising to me.

I suppose if you test this repo on any hackers computer they probably have git installed. Indeed, macOS comes with it installed, IIRC. However, Ubuntu 14.04 does not. Seems like it should be mentioned.

Sorry that my first contribution is a weak readme update. I promise to be more helpful in the future!