### PR TITLE
macOS homebrew install file

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,20 @@
 
 This is a [Secure Scuttlebutt](http://scuttlebutt.nz) system tray application. It provides an always-running _sbot_ for your local system.
 
-## Dependencies
+## Install on macOS through [Homebrew](https://brew.sh)
+
+Did not make a pull-request to the main repo yet but you can use this:
+
+```
+homebrew install https://raw.githubusercontent.com/ssbc/scuttle-shell/homebrew/scuttleshell.rb
+```
+
+## Install from source
+
+### Dependencies
 
 You must have [Git](https://git-scm.com) and [Node](https://nodejs.org) installed.
 
-## Install globally
 
 ```
 $ npm install -g scuttle-shell

--- a/scuttleshell.rb
+++ b/scuttleshell.rb
@@ -1,0 +1,23 @@
+# https://docs.brew.sh/Node-for-Formula-Authors
+
+require "language/node"
+
+class Scuttleshell < Formula
+  desc "A system tray app for running Secure Scuttlebutt and providing sbot features to your local system"
+  homepage "https://github.com/ssbc/scuttle-shell"
+  url "https://registry.npmjs.org/scuttle-shell/-/scuttle-shell-1.0.0.tgz"
+  version '1.0.0'
+  sha256 "0aa6369f89c8c6b8510ee138ead11209da78f667cfdd98c885df7e9bcc84ae74"
+
+  depends_on "node@10"
+  depends_on "python" => :build
+
+  def install
+    system "npm", "install", *Language::Node.std_npm_install_args(libexec)
+    bin.install_symlink Dir["#{libexec}/bin/*"]
+  end
+
+  test do
+    system "scuttleshell"
+  end
+end


### PR DESCRIPTION
Wanted to supply an easier install method can't get past this point:

```
npm verb argv "/usr/local/Cellar/node@10/10.15.0/bin/node" "/usr/local/opt/node/libexec/bin/npm" "install" "-ddd" "--global" "--build-from-source" "--cache=/Users/cryptix/Library/Caches/Homebrew/npm_cache" "--prefix=/usr/local/Cellar/scuttleshell/1.0.0/libexec" "/private/tmp/scuttleshell-20190202-12673-17x1n5d/package/scuttle-shell-1.0.0.tgz"
npm verb node v10.15.0
npm verb npm  v6.5.0
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! sodium-native@2.2.5 install: `node-gyp-build "node preinstall.js" "node postinstall.js"`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the sodium-native@2.2.5 install script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
npm verb exit [ 1, true ]
npm timing npm Completed in 36888ms

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/cryptix/Library/Caches/Homebrew/npm_cache/_logs/2019-02-02T10_57_45_802Z-debug.log

```